### PR TITLE
Add clickable link to lobby that opens in new tab

### DIFF
--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -27,6 +27,7 @@
 .game .game-name-wrapper {
 	display: flex;
 	justify-content: center;
+	cursor: pointer;
 }
 
 .game .game-name {

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -668,6 +668,10 @@ export function TopBar(props) {
 		);
 	}
 
+	function onLogoClick() {
+		window.open("https://beyondmafia.com/", "_blank");
+    }
+
 	function onSettingsClick() {
 		props.setShowSettingsModal(true);
 	}
@@ -726,7 +730,7 @@ export function TopBar(props) {
 
 	return (
 		<div className="top">
-			<div className="game-name-wrapper">
+			<div className="game-name-wrapper" onClick={onLogoClick}>
 				{props.gameName}
 			</div>
 			<div className="state-wrapper">


### PR DESCRIPTION
Taking care of suggestion #18.
User wants the game name logo to be clickable, and the link will open the lobby page. I took the meaning that they want it open in a new tab, rather than overriding the current page.