### PR TITLE
Removing new lines from last will

### DIFF
--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -197,7 +197,7 @@ module.exports = class Player {
 				if (!this.game.setup.lastWill)
 					return;
 
-				will = String(will).slice(0, constants.maxWillLength);
+				will = String(will).replace(/[\r\n]/gm, "").slice(0, constants.maxWillLength);
 				this.lastWill = will;
 			}
 			catch (e) {

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -197,7 +197,8 @@ module.exports = class Player {
 				if (!this.game.setup.lastWill)
 					return;
 
-				will = String(will).replace(/[\r\n]/gm, "").slice(0, constants.maxWillLength);
+				will = String(will).slice(0, constants.maxWillLength);
+				will = this.processWill(will);
 				this.lastWill = will;
 			}
 			catch (e) {
@@ -237,6 +238,23 @@ module.exports = class Player {
 			}
 		});
 	}
+
+	processWill(inputString) {
+		//Purpose is to process and allow only 2 new line characters (\n) maximum.
+		let newLineCount = 0;
+		let outputString = "";
+
+		for (let i = 0; i < inputString.length; i++) {
+			if (inputString[i] === '\n')
+				newLineCount++;
+		}
+
+		if (newLineCount > 2) {
+			let newLineArr = inputString.split('\n');
+			outputString = newLineArr.slice(0, 3).join('\n') + newLineArr.slice(3).join(' ');
+		}
+		return outputString;
+}
 
 	parseCommand(message) {
 		var split = message.content.replace("/", "").split(" ");

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -239,22 +239,12 @@ module.exports = class Player {
 		});
 	}
 
-	processWill(inputString) {
-		//Purpose is to process and allow only 2 new line characters (\n) maximum.
-		let newLineCount = 0;
-		let outputString = "";
-
-		for (let i = 0; i < inputString.length; i++) {
-			if (inputString[i] === '\n')
-				newLineCount++;
-		}
-
-		if (newLineCount > 2) {
-			let newLineArr = inputString.split('\n');
-			outputString = newLineArr.slice(0, 3).join('\n') + newLineArr.slice(3).join(' ');
-		}
-		return outputString;
-}
+	processWill(will) {
+		var newLineArr = will.split('\n');
+		will = newLineArr.slice(0, constants.maxWillNewLines).join('\n') +
+			newLineArr.slice(constants.maxWillNewLines).join(' ');
+		return will;
+	}
 
 	parseCommand(message) {
 		var split = message.content.replace("/", "").split(" ");

--- a/data/constants.js
+++ b/data/constants.js
@@ -100,6 +100,7 @@ module.exports = {
 	maxGameMessageLength: 240,
 	maxGameTextInputLength: 100,
 	maxWillLength: 100,
+	maxWillNewLines: 4,
 	maxSetupNameLength: 25,
 	gameReserveTime: 5 * 60 * 1000,
 


### PR DESCRIPTION
A trick to make the last will extra long by adding new line characters has been seen. This will fix that from happening.

I'm open to trying to find a better way to allow new line characters, but in certain cases where the user actually typed words, and would like to use new lines to separate sentences. Using regex maybe. For now, removing new lines will fix the "exploit" nuisance.