### PR TITLE
Bugfix for associate role

### DIFF
--- a/Games/types/Mafia/roles/cards/AssoGunGiver.js
+++ b/Games/types/Mafia/roles/cards/AssoGunGiver.js
@@ -10,6 +10,7 @@ module.exports = class AssoGunGiver extends Card {
 			"Give Gun": {
 				states: ["Night"],
 				flags: ["voting"],
+				targets: { include: ["alive"], exclude: ["Mafia"] },
 				action: {
 					labels: ["giveItem", "gun"],
 					priority: PRIORITY_ASSOGUN_GIVER,


### PR DESCRIPTION
Forgot to include the extra conditions for the valid targets in the associate meeting. Target should be alive, and cannot be mafia.