### PR TITLE
suggestion: do not show "first game" modal for bots

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -528,7 +528,7 @@ module.exports = class Game {
 		player.send("setup", this.getSetupInfo());
 		player.send("emojis", this.emojis);
 
-		if (!player.user.playedGame)
+		if (!player.user.playedGame && !player.isBot)
 			player.send("firstGame");
 
 		if (player.user.dev && !player.isBot)


### PR DESCRIPTION
pros: it's a quality of life addition for developers, need not have to keep seeing the modal.
cons: unable to use bot accounts to efficiently test the "firstGame" function [need to actually create a new account/ manually disable it in the code]

it's up to you if you want to keep it~=