### PR TITLE
ui: increase contrast tolerance to allow lighter colours

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -394,7 +394,7 @@ router.post("/settings/update", async function (req, res) {
             // YIQ equation from http://24ways.org/2010/calculating-color-contrast
 
             // original value was 0.5
-            const contrastTolerance = 0.6
+            const contrastTolerance = 0.6;
 
 		    const rgb = c.rgb().color;
 		    const yiq = (rgb[0] * 2126 + rgb[1] * 7152 + rgb[2] * 722) / 10000;

--- a/routes/user.js
+++ b/routes/user.js
@@ -395,10 +395,10 @@ router.post("/settings/update", async function (req, res) {
 
             // original value was 0.5
             const contrastTolerance = 0.6;
-
-		    const rgb = c.rgb().color;
-		    const yiq = (rgb[0] * 2126 + rgb[1] * 7152 + rgb[2] * 722) / 10000;
-		    const isLight = yiq >= contrastTolerance * 256;
+            
+            const rgb = c.rgb().color;
+            const yiq = (rgb[0] * 2126 + rgb[1] * 7152 + rgb[2] * 722) / 10000;
+            const isLight = yiq >= contrastTolerance * 256;
 
             if ((prop == "textColor" || prop == "nameColor") && isLight) {
                 res.status(500);

--- a/routes/user.js
+++ b/routes/user.js
@@ -389,7 +389,18 @@ router.post("/settings/update", async function (req, res) {
         if (prop == "backgroundColor" || prop == "textColor" || prop == "nameColor") {
             var c = new color(value);
 
-            if ((prop == "textColor" || prop == "nameColor") && c.isLight()) {
+            // replaced c.isLight() with a manual check
+            // original function https://github.com/Qix-/color/blob/master/index.js#L298
+            // YIQ equation from http://24ways.org/2010/calculating-color-contrast
+
+            // original value was 0.5
+            const contrastTolerance = 0.6
+
+		    const rgb = c.rgb().color;
+		    const yiq = (rgb[0] * 2126 + rgb[1] * 7152 + rgb[2] * 722) / 10000;
+		    const isLight = yiq >= contrastTolerance * 256;
+
+            if ((prop == "textColor" || prop == "nameColor") && isLight) {
                 res.status(500);
                 res.send("Color is too light.");
                 return;


### PR DESCRIPTION
Re-implemented the YIQ equation isLight() at `/routes/user.js` from [here](https://github.com/Qix-/color/blob/master/index.js#L298). 

The YIQ is a grayscale score from 0 to 1. A smaller number is a darker colour. With a light background, we want users to pick darker colours.

The existing algorithm rejects colours with a score >= 0.5.
I changed it to only reject colours with a score >=0.6