### PR TITLE
profile colours: allow users to pick lighter in-game colours

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -400,7 +400,7 @@ router.post("/settings/update", async function (req, res) {
             const yiq = (rgb[0] * 2126 + rgb[1] * 7152 + rgb[2] * 722) / 10000;
             const isLight = yiq >= contrastTolerance * 256;
 
-            if ((prop == "textColor" || prop == "nameColor") && c.isLight()) {
+            if ((prop == "textColor" || prop == "nameColor") && isLight) {
                 res.status(500);
                 res.send("Color is too light.");
                 return;

--- a/routes/user.js
+++ b/routes/user.js
@@ -389,6 +389,17 @@ router.post("/settings/update", async function (req, res) {
         if (prop == "backgroundColor" || prop == "textColor" || prop == "nameColor") {
             var c = new color(value);
 
+            // replaced c.isLight() with a manual check
+            // original function https://github.com/Qix-/color/blob/master/index.js#L298
+            // YIQ equation from http://24ways.org/2010/calculating-color-contrast
+
+            // original value was 0.5
+            const contrastTolerance = 0.6;
+            
+            const rgb = c.rgb().color;
+            const yiq = (rgb[0] * 2126 + rgb[1] * 7152 + rgb[2] * 722) / 10000;
+            const isLight = yiq >= contrastTolerance * 256;
+
             if ((prop == "textColor" || prop == "nameColor") && c.isLight()) {
                 res.status(500);
                 res.send("Color is too light.");


### PR DESCRIPTION
Re-implemented the YIQ equation isLight() at `/routes/user.js` from [here](https://github.com/Qix-/color/blob/master/index.js#L298). 

The YIQ is a grayscale score from 0 to 1. A smaller number is a darker colour. With a light background, we want users to pick darker colours.
            
The existing algorithm rejects colours with a score >= 0.5.
I changed it to only reject colours with a score >=0.6.

Personal thoughts: This is quite highly requested but I increasing the value too much might make the site less visually accessible.