### PR TITLE
fix: remove meeting flag hidden and absolute

### DIFF
--- a/Games/types/Mafia/const/MeetingFlag.js
+++ b/Games/types/Mafia/const/MeetingFlag.js
@@ -19,9 +19,6 @@ FLAG_ANONYMOUS = "anonymous"
 
 FLAG_MUST_ACT = "mustAct"
 
-FLAG_HIDDEN = "hidden"
-FLAG_ABSOLUTE = "absolute"
-
 module.exports = {
     FLAG_LIVE_JOIN,
     FLAG_VOTING,
@@ -33,6 +30,4 @@ module.exports = {
     FLAG_ANONYMOUS,
     
     FLAG_MUST_ACT,
-    FLAG_HIDDEN,
-    FLAG_ABSOLUTE,
 }

--- a/Games/types/Mafia/roles/cards/SwapRoles.js
+++ b/Games/types/Mafia/roles/cards/SwapRoles.js
@@ -9,8 +9,9 @@ module.exports = class SwapRoles extends Card {
         this.meetings = {
             "Swap Roles": {
                 states: ["Night"],
-                flags: ["voting", "hidden", "absolute"],
+                flags: ["voting"],
                 action: {
+                    labels: ["hidden", "absolute"],
                     priority: PRIORITY_SWAP_ROLES,
                     run: function () {
                         var currRoleName = this.actor.role.name;


### PR DESCRIPTION
I see this "hidden" and "absolute" flag in SwapRoles meeting

if i'm not wrong "hidden" and "absolute" should be labels instead of flags 
don't see a meeting property .hidden or .absolute...

this change was made in a previous commit, i think it was an accident

![image](https://user-images.githubusercontent.com/24848927/212945330-25fa6028-0493-4b29-a762-25bed1b3bc1a.png)
