### PR TITLE
[TESTED] slight matchmaker rework

### DIFF
--- a/Games/types/Mafia/roles/cards/MeetYourMatch.js
+++ b/Games/types/Mafia/roles/cards/MeetYourMatch.js
@@ -7,22 +7,32 @@ module.exports = class MeetYourMatch extends Card {
         super(role);
 
         this.meetings = {
-            "Setup a Date (2)": {
+            "Lovebird A": {
                 states: ["Night"],
-                flags: ["voting", "multi"],
-                multiMin: 2,
-                multiMax: 2,
+                flags: ["voting"],
+                action: {
+                    priority: PRIORITY_ITEM_GIVER_DEFAULT - 1,
+                    run: function() {
+                        this.actor.role.data.lovebirdA = this.target;
+                    }
+                },
+            },
+            "Lovebird B": {
+                states: ["Night"],
+                flags: ["voting"],
                 action: {
                     labels: ["effect", "love"],
                     priority: PRIORITY_ITEM_GIVER_DEFAULT,
                     run: function() {
-                        var lovebirdA = this.target[0];
-                        var lovebirdB = this.target[1];
+                        if (!this.actor.role.data.lovebirdA)
+                            return
+                        let lovebirdA = this.actor.role.data.lovebirdA;
+                        let lovebirdB = this.target;
 
-                        var alignmentA = lovebirdA.role.alignment;
-                        var alignmentB = lovebirdB.role.alignment;
-                        var alert;
-                        if (alignmentA == alignmentB) {
+                        let alignmentA = lovebirdA.role.winCount ? lovebirdA.role.winCount : lovebirdA.role.alignment;
+                        let alignmentB = lovebirdB.role.winCount ? lovebirdB.role.winCount : lovebirdB.role.alignment;
+                        let alert;
+                        if (alignmentA === alignmentB) {
                             lovebirdA.giveEffect("Love", this.actor);
                             lovebirdB.giveEffect("Love", this.actor);
                             alert = `${lovebirdA.name} and ${lovebirdB.name}'s date went well. They are now in love.`;
@@ -30,6 +40,7 @@ module.exports = class MeetYourMatch extends Card {
                             alert = `${lovebirdA.name} and ${lovebirdB.name}'s date went poorly. Better luck next time.`;
                         }
                         this.actor.queueAlert(alert)
+                        delete this.actor.role.data.lovebirdA;
                     }
                 },
             }

--- a/data/roles.js
+++ b/data/roles.js
@@ -510,7 +510,7 @@ const roleData = {
         "Matchmaker": {
             alignment: "Independent",
             description: [
-                "Each night chooses too people to go on a date. If those two are the same role, they will fall in love.",
+                "Each night chooses two people to go on a date. If those two are the same alignment, they will fall in love.",
                 "Wins if all players left alive are in love.",
             ],
         },


### PR DESCRIPTION
I originally tested matchmaker with two meetings, then refactored to multimeeting by request, however I realized soon after that multimeeting dramatically nerfs matchmaker because it cannot select the same person twice, making it impossible to win in some situations, so I've reverted that change.

I also allowed matchmaker to count winCount if it exists instead of alignment, allowing non-hostile 3rds to match with town. (And mastermind to match with mafia). 

