### PR TITLE
orange now counts as food for famine

### DIFF
--- a/Games/types/Mafia/effects/Famished.js
+++ b/Games/types/Mafia/effects/Famished.js
@@ -24,6 +24,8 @@ module.exports = class Famished extends Effect {
 
                 if (this.player.hasItem("Bread")){
                     this.player.dropItem("Bread", false);
+                } else if (this.player.hasItem("Orange")){
+                    this.player.dropItem("Orange", false);
                 }else{
                     this.game.queueAction(new Action({
                         actor: this.player,


### PR DESCRIPTION
Eating an orange will now help a player survive a famine. Oranges are edible so they should be able to be eaten in a famine situation.