### PR TITLE
add journalist informant

### DIFF
--- a/Games/types/Mafia/roles/Mafia/Informant.js
+++ b/Games/types/Mafia/roles/Mafia/Informant.js
@@ -1,0 +1,17 @@
+const Role = require("../../Role");
+
+module.exports = class Informant extends Role {
+
+    constructor(player, data) {
+        super("Informant", player, data);
+
+        this.alignment = "Mafia";
+        this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "AlertLearner"];
+        this.meetingMods = {
+            "Get scoop on": {
+                targets: { include: ["alive"], exclude: ["Mafia", "self"] },
+            }
+        };
+    }
+
+}

--- a/Games/types/Mafia/roles/Village/Journalist.js
+++ b/Games/types/Mafia/roles/Village/Journalist.js
@@ -1,0 +1,12 @@
+const Role = require("../../Role");
+
+module.exports = class Journalist extends Role {
+
+    constructor(player, data) {
+        super("Journalist", player, data);
+
+        this.alignment = "Village";
+        this.cards = ["VillageCore", "WinWithVillage", "AlertLearner"];
+    }
+
+}

--- a/Games/types/Mafia/roles/cards/AlertLearner.js
+++ b/Games/types/Mafia/roles/cards/AlertLearner.js
@@ -1,0 +1,36 @@
+const Card = require("../../Card");
+const { PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT } = require("../../const/Priority");
+
+module.exports = class AlertLearner extends Card {
+
+    constructor(role) {
+        super(role);
+
+        this.meetings = {
+            "Get scoop on": {
+                states: ["Night"],
+                flags: ["voting"],
+                targets: { include: ["alive"], exclude: ["self"] },
+                action: {
+                    labels: ["investigate", "alerts"],
+                    priority: PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT + 1,
+                    run: function () {
+                        var reports = []
+
+                        for (let alert of this.game.alertQueue) {
+                            for (let recipient of alert.recipients) {
+                                if (recipient == this.target) {
+                                    reports.push(alert.message);
+                                }
+                            }
+                        }
+
+                        var alert = `You received all reports that ${this.target.name} received: (${reports.join(',\n')}).`;
+                        this.actor.queueAlert(alert);
+                    }
+                }
+            }
+        };
+    }
+
+}

--- a/data/roles.js
+++ b/data/roles.js
@@ -367,6 +367,12 @@ const roleData = {
                 "That person will be resurrected.",
             ],
         },
+        "Journalist": {
+            alignment: "Village",
+            description: [
+                "Each night, learns the system messages received by their target."
+            ]
+        },
 
         //Mafia
         "Mafioso": {
@@ -534,6 +540,12 @@ const roleData = {
                 "Once per game, visits one dead person during the night.",
                 "That person will be resurrected.",
             ],
+        },
+        "Informant": {
+            alignment: "Mafia",
+            description: [
+                "Each night, learns the system messages received by their target."
+            ]
         },
 
         //Monsters


### PR DESCRIPTION
I used the alertQueue to pull messages.

If journ/informant go on each other, M went on H and H went on M only one person gets the scoop.

![image](https://user-images.githubusercontent.com/24848927/216616106-07238ca8-6c67-4c1d-95f9-55fa249d853e.png)
The other person receives no scoop, and also prevents the infinite loop.

---

it cannot get guiser messages properly
--> on guiser who guiserkilled = no messages
--> on target who was guisekilled = infinite loop