### PR TITLE
feat(ui): add resistance scoreboard

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -769,11 +769,13 @@ module.exports = class Game {
 
         // Tell clients the new state
         this.addStateToHistories(stateInfo.name);
+
         this.broadcastState();
         this.events.emit("state", stateInfo);
 
         // Send state events
-        this.addStateEventsToHistories(this.stateEvents)
+        this.addStateEventsToHistories(this.stateEvents);
+        this.addStateExtraInfoToHistories(stateInfo.extraInfo);
         this.broadcast("stateEvents", Object.keys(this.stateEvents));
         this.events.emit("stateEvents", this.stateEvents);
         this.sendStateEventMessages();
@@ -815,6 +817,14 @@ module.exports = class Game {
 
         for (let player of this.players)
             player.addStateEventsToHistory(events, state);
+    }
+
+    addStateExtraInfoToHistories(extraInfo, state) {
+        this.history.addStateExtraInfo(extraInfo, state);
+        this.spectatorHistory.addStateExtraInfo(extraInfo, state);
+
+        for (let player of this.players)
+            player.addStateExtraInfoToHistory(extraInfo, state);
     }
 
     incrementState() {

--- a/Games/core/History.js
+++ b/Games/core/History.js
@@ -30,7 +30,8 @@ module.exports = class History {
             alerts: [],
             stateEvents: {},
             roles: { ...this.states[prevState].roles },
-            dead: { ...this.states[prevState].dead }
+            dead: { ...this.states[prevState].dead },
+            extraInfo: {},
         };
     }
 
@@ -40,6 +41,13 @@ module.exports = class History {
 
         for (let eventName in events)
             state.stateEvents[eventName] = events[eventName];
+    }
+
+    addStateExtraInfo(extraInfo, state) {
+        state = state == null ? this.game.currentState : state;
+        state = this.states[state];
+
+        state.extraInfo = extraInfo;
     }
 
     addMeeting(meeting, state) {
@@ -98,7 +106,8 @@ module.exports = class History {
                 alerts: [],
                 stateEvents: Object.keys(info.stateEvents),
                 roles: info.roles,
-                dead: info.dead
+                dead: info.dead,
+                extraInfo: info.extraInfo
             };
 
             for (let meetingId in info.meetings) {

--- a/Games/core/Player.js
+++ b/Games/core/Player.js
@@ -353,6 +353,10 @@ module.exports = class Player {
         this.history.addStateEvents(events, state);
     }
 
+    addStateExtraInfoToHistory(extraInfo, state) {
+        this.history.addStateExtraInfo(extraInfo, state);
+    }
+
     speak(message) {
         const originalMessage = message;
         message = new Message(message);

--- a/Games/types/Resistance/Game.js
+++ b/Games/types/Resistance/Game.js
@@ -39,6 +39,13 @@ module.exports = class ResistanceGame extends Game {
         this.numMissions = this.setup.numMissions;
         this.currentMissionFails = 0;
 
+        // scorekeeping
+        this.currentMissionHistory = null;
+        this.missionRecord = {
+            missionHistory: [],
+            score: { "rebels": 0, "spies": 0 }
+        }
+
         this.teamFails = 0;
         this.currentTeamFail = false;
         this.teamFailLimit = this.setup.teamFailLimit;
@@ -70,6 +77,8 @@ module.exports = class ResistanceGame extends Game {
             }
             else
                 this.queueAlert(`Mission ${this.mission} succeeded.`);
+            
+            this.recordMissionFails(this.currentMissionFails);
 
             this.mission++;
             this.currentMissionFails = 0;
@@ -91,6 +100,28 @@ module.exports = class ResistanceGame extends Game {
         }
     }
 
+    recordMissionTeam(team) {
+        this.currentMissionHistory = {
+            mission: this.mission,
+            team: team
+        }
+    }
+
+    recordMissionFails(numFails) {
+        if (!this.currentMissionHistory) {
+            // unintended behaviour
+            return;
+        }
+
+        this.currentMissionHistory.numFails = numFails;
+        const winningTeam = this.currentMissionHistory.numFails == 0 ? "rebels" : "spies";
+
+        // update mission record
+        this.missionRecord.missionHistory.push(this.currentMissionHistory);
+        this.missionRecord.score[winningTeam] += 1;
+        this.currentMissionHistory = null;
+    }
+
     getStateInfo(state) {
         var info = super.getStateInfo(state);
         info.mission = this.mission;
@@ -101,6 +132,8 @@ module.exports = class ResistanceGame extends Game {
                 name: `Mission ${this.mission}`
             }
         }
+
+        info.extraInfo = this.missionRecord;
 
         return info;
     }

--- a/Games/types/Resistance/items/Leader.js
+++ b/Games/types/Resistance/items/Leader.js
@@ -32,7 +32,11 @@ module.exports = class Leader extends Item {
 
                         this.actor.role.meetings["Approve Team"].disabled = true;
 
-                        this.game.queueAlert(`Team selected: ${this.target.map(t => t.name).join(", ")}`);
+                        var selectedNames = this.target.map(t => t.name);
+                        // for displaying mission history
+                        this.game.recordMissionTeam(selectedNames);
+                        
+                        this.game.queueAlert(`Team selected: ${selectedNames.join(", ")}`);
                         this.actor.dropItem("Leader");
                     }
                 }

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -622,6 +622,105 @@
 	color: black;
 }
 
+/* resistance */
+
+.game .rst {
+	display: flex;
+	flex-flow: column;
+	align-items: center;
+
+	margin-bottom: 10px;
+	padding: 0px 5px;
+
+	color: #bd4c4c;
+}
+
+.game .rst-name {
+	margin-top: 10px;
+	padding-top: 0px;
+
+	font-weight: bold;
+}
+
+.game .rst-score {
+	display: flex;
+	justify-content: center;
+	flex-wrap: nowrap;
+
+	margin-bottom: 10px;
+	padding: 0px 5px;
+}
+
+.game .rst-score-box {
+	float: left;
+	margin: 10px 10px;
+}
+
+.game .rst-score-box-name {
+	margin: 10px auto;
+	text-align: center;
+
+	font-weight: bold;
+
+	color: #bd4c4c;
+}
+
+.game .rst-score-box-value {
+	width:100px;
+	height:100px;
+
+	text-align: center;
+
+	display: table-cell;
+	vertical-align: middle;
+	font-size: 60px;
+
+	color: black;
+}
+
+.game .rst-score-box-rebels {
+	background-color: #66afef;
+}
+
+.game .rst-score-box-spies {
+	background-color: #ff4e4e;
+}
+
+.game .rst-mh-all-rows {
+	flex-flow: row wrap;
+}
+
+.game .rst-mh-row {
+	display: flex;
+	float: left;
+}
+
+.game .rst-mh-status {
+	width: 20px;
+	height: 20px;
+	-moz-border-radius: 10px; 
+	-webkit-border-radius: 10px; 
+	border-radius: 10px;
+	text-align: center;
+	color: black;
+}
+
+.game .rst-mh-success {
+	background: #66afef; 
+}
+
+.game .rst-mh-fail {
+	background: #ff4e4e;
+}
+
+.game .rst-mh-team {
+	padding: 0px 5px;
+
+	flex-flow: row wrap;
+	margin-left: 5px;
+	color: black;
+}
+
 .game .last-will-wrapper,
 .game .notes-wrapper {
 	display: flex;

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -2132,7 +2132,8 @@ function useHistoryReducer() {
                                     alerts: [],
                                     stateEvents: [],
                                     roles: { ...history.states[prevState].roles },
-                                    dead: { ...history.states[prevState].dead }
+                                    dead: { ...history.states[prevState].dead },
+                                    extraInfo: { ...action.state.extraInfo }
                                 }
                             }
                         },


### PR DESCRIPTION
- pass extraInfo from backend state to allow custom games like resistance/ ghost to pass in game-specific information for display
- add scoreboard that shows past Approved missions and the current tally

**the rows show how many failures were chosen that round**
![image](https://user-images.githubusercontent.com/24848927/218527911-d489fc59-c681-4709-8fb3-46b7cd630552.png)

**no dark mode support yet, but the red/ blue are dark-mode compatible**
![image](https://user-images.githubusercontent.com/24848927/218528057-3336550c-ec05-44c3-94ff-c87594e11977.png)
