### PR TITLE
feat: add kickvoting

### DIFF
--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -640,7 +640,10 @@ module.exports = class Meeting {
                     (!this.multi && this.votes[member.id] == null) ||
                     (this.multi && selections.length < this.multiMin && selections.indexOf("*") == -1)
                 ) {
-                    this.game.vegPlayer(member.player);
+                    const isKickEliminated = this.actionName === "Village Vote" && this.finalTarget === member.id;
+                    if (!isKickEliminated) {
+                        this.game.vegPlayer(member.player);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #126 

- If the player is going to be the village elimination, do nothing
- Else, veg the player

Most of the code is taken from #324 
The key difference is that in this branch, the village-eliminated player does not get vegPlayer called, it's treated as a normal death - no vegPlayer, no deathType veg, no playerLeave