### PR TITLE
bugfix: fix jester test case

### DIFF
--- a/Games/types/Mafia/roles/cards/WinIfLynched.js
+++ b/Games/types/Mafia/roles/cards/WinIfLynched.js
@@ -10,7 +10,7 @@ module.exports = class WinIfLynched extends Card {
             priority: PRIORITY_WIN_IF_LYNCHED,
             againOnFinished: true,
             check: function (counts, winners, aliveCount) {
-                if (this.data.lynched) {
+                if (this.data.lynched && !winners.groups[this.name]) {
                     winners.addPlayer(this.player, this.name);
                     return true;
                 }

--- a/test/Games/Mafia.test.js
+++ b/test/Games/Mafia.test.js
@@ -276,7 +276,7 @@ describe("Games/Mafia", function () {
     });
 
     describe("Jester", function () {
-        it("should be able to joint win when voted off", async function () {
+        it("should make only the Jester win when he is voted off", async function () {
             await db.promise;
             await redis.client.flushdbAsync();
 
@@ -301,7 +301,7 @@ describe("Games/Mafia", function () {
 
             await waitForGameEnd(game);
             should.exist(game.winners.groups["Jester"]);
-            should.exist(game.winners.groups["Mafia"]);
+            should.not.exist(game.winners.groups["Mafia"]);
             should.not.exist(game.winners.groups["Village"]);
             game.winners.groups["Jester"].should.have.lengthOf(1);
         });


### PR DESCRIPTION
I realised that winChecks with `againOnFinished` need to check if winners.group["winGroup"] exists

Fixes #229 