### PR TITLE
Added Graveyard Participation

### DIFF
--- a/data/roles.js
+++ b/data/roles.js
@@ -386,7 +386,7 @@ const roleData = {
                 "Appears as villager until death.",
                 "Once dead, may visit one person a night and roleblock them.",
             ],
-            graveyardParticipationSelf: true,
+            graveyardParticipation: "self",
         },
         "Lightkeeper": {
             alignment: "Village",
@@ -401,7 +401,7 @@ const roleData = {
                 "Once per game, visits one dead person during the night.",
                 "That person will be resurrected.",
             ],
-            graveyardParticipationOther: true,
+            graveyardParticipation: "all",
         },
         "Trickster": {
             alignment: "Village",
@@ -417,7 +417,7 @@ const roleData = {
                 "Chooses a dead player per night and holds a seance with that player.",
                 "Medium's identity is not revealed to the dead player.",  
             ],
-            graveyardParticipationOther: true,
+            graveyardParticipation: "all",
         },
         "Robin Hood": {
             alignment: "Village",
@@ -675,7 +675,7 @@ const roleData = {
                 "Once per game, visits one dead person during the night.",
                 "That person will be resurrected.",
             ],
-            graveyardParticipationOther: true,
+            graveyardParticipation: "all",
         },
         "Mummy": {
             alignment: "Mafia",
@@ -688,7 +688,7 @@ const roleData = {
             description: [
                 "Once dead, may visit one person a night and roleblock them.",
            ],
-           graveyardParticipationSelf: true,
+           graveyardParticipation: "self",
         },
         "Informant": {
             alignment: "Mafia",
@@ -780,7 +780,7 @@ const roleData = {
                 "Chooses a dead player per night and holds a seance with that player.",
                 "Crank's identity is not revealed to the dead player.",  
             ],
-            graveyardParticipationOther: true,
+            graveyardParticipation: "all",
         },
 
         //Monsters
@@ -916,7 +916,7 @@ const roleData = {
                 "If killed by any other players in a way that is not the village vote, will gain the ability to kill a player each night in the graveyard.",
                 "Wins if it kills all of its murderers.",
             ],
-            graveyardParticipationSelf: true,
+            graveyardParticipation: "self",
         },
         "Clockmaker": {
             alignment: "Independent",

--- a/data/roles.js
+++ b/data/roles.js
@@ -386,6 +386,7 @@ const roleData = {
                 "Appears as villager until death.",
                 "Once dead, may visit one person a night and roleblock them.",
             ],
+            graveyardParticipationSelf: true,
         },
         "Lightkeeper": {
             alignment: "Village",
@@ -400,6 +401,7 @@ const roleData = {
                 "Once per game, visits one dead person during the night.",
                 "That person will be resurrected.",
             ],
+            graveyardParticipationOther: true,
         },
         "Trickster": {
             alignment: "Village",
@@ -415,6 +417,7 @@ const roleData = {
                 "Chooses a dead player per night and holds a seance with that player.",
                 "Medium's identity is not revealed to the dead player.",  
             ],
+            graveyardParticipationOther: true,
         },
         "Robin Hood": {
             alignment: "Village",
@@ -672,6 +675,7 @@ const roleData = {
                 "Once per game, visits one dead person during the night.",
                 "That person will be resurrected.",
             ],
+            graveyardParticipationOther: true,
         },
         "Mummy": {
             alignment: "Mafia",
@@ -684,6 +688,7 @@ const roleData = {
             description: [
                 "Once dead, may visit one person a night and roleblock them.",
            ],
+           graveyardParticipationSelf: true,
         },
         "Informant": {
             alignment: "Mafia",
@@ -775,6 +780,7 @@ const roleData = {
                 "Chooses a dead player per night and holds a seance with that player.",
                 "Crank's identity is not revealed to the dead player.",  
             ],
+            graveyardParticipationOther: true,
         },
 
         //Monsters
@@ -910,6 +916,7 @@ const roleData = {
                 "If killed by any other players in a way that is not the village vote, will gain the ability to kill a player each night in the graveyard.",
                 "Wins if it kills all of its murderers.",
             ],
+            graveyardParticipationSelf: true,
         },
         "Clockmaker": {
             alignment: "Independent",


### PR DESCRIPTION
Added graveyard participation tags to roles:

graveyardParticipationSelf: players with this role must stay in a ranked game while dead
graveyardParticipationOther: players in a game with this role must stay in a ranked game while dead