### PR TITLE
refactor: clarify governor overturn no one effect

### DIFF
--- a/data/roles.js
+++ b/data/roles.js
@@ -103,7 +103,8 @@ const roleData = {
         "Governor": {
             alignment: "Village",
             description: [
-                "Can override a lynch once per game. (including no-lynches)"
+                "Once a game, when the village decides to eliminate someone, can override the village vote",
+                "Cannot cancel a village vote. Choosing no one preserves the governor's ability."
             ],
         },
         "Monkey": {


### PR DESCRIPTION
when overturning, the gov votes "no one"

this can be confusing to mean two things
1. gov chooses not to use his overturn action (current mechanic)
2. gov chooses to use his overturn action, and throw the vote to "no one"