### PR TITLE
Video dupe fix

### DIFF
--- a/react_main/src/pages/User/Profile.jsx
+++ b/react_main/src/pages/User/Profile.jsx
@@ -81,14 +81,13 @@ export default function Profile() {
                     setFriendsPage(1);
                     setStats(res.data.stats);
                     setGroups(res.data.groups);
+                    setEmbedId("");
+                    setAutoplay(false);
 
                     if(res.data.settings.youtube !== undefined) {
                         var videoMatches = res.data.settings.youtube.match(youtubeRegex) ?? "";
                         if (videoMatches && videoMatches.length >= 7) {
                             setEmbedId(videoMatches[7]);
-                        }
-                        else {
-                            setEmbedId("");
                         }
                         setAutoplay(res.data.settings.autoplay);
                     }


### PR DESCRIPTION
Fixed the bug where if a profile doesn't have a video, it doesn't load the last loaded video from another profile. Just needed to set the embedId default when loading new profile.