### PR TITLE
bugfix: check for multimeeting target in visitors

### DIFF
--- a/Games/types/Mafia/Action.js
+++ b/Games/types/Mafia/Action.js
@@ -26,11 +26,15 @@ module.exports = class MafiaAction extends Action {
 
         var visitors = [];
         for (let action of this.game.actions[0]) {
-            if (
-                action.target == this.actor &&
-                !action.hasLabel("hidden")
-            ) {
-                visitors.push(action.actor);
+            let toCheck = action.target;
+            if (!Array.isArray(action.target)) {
+                toCheck = [action.target];
+            }
+
+            for (let target of toCheck) {
+                if (target == this.actor && !action.hasLabel("hidden")) {
+                    visitors.push(action.actor);
+                }
             }
         }
 

--- a/Games/types/Mafia/roles/Village/Loudmouth.js
+++ b/Games/types/Mafia/roles/Village/Loudmouth.js
@@ -10,7 +10,6 @@ module.exports = class Loudmouth extends Role {
             "VillageCore",
             "WinWithVillage",
             "Humble",
-            "EnqueueVisitors",
             "CryOutVisitors"];
     }
 

--- a/Games/types/Mafia/roles/cards/CryOutVisitors.js
+++ b/Games/types/Mafia/roles/cards/CryOutVisitors.js
@@ -14,9 +14,8 @@ module.exports = class CryOutVisitors extends Card {
                     if (this.game.getStateName() != "Night")
                         return;
 
-                    let visitors = this.actor.role.data.visitors;
-
-                    if(visitors?.length){
+                    let visitors = this.getVisitors();
+                    if (visitors?.length) {
                         let names = visitors?.map(visitor => visitor.name);
                         this.game.queueAlert(`Someone shouts during the night: `
                             + `Curses! ${names.join(", ")} disturbed my slumber!`);

--- a/Games/types/Mafia/roles/cards/EnqueueVisitors.js
+++ b/Games/types/Mafia/roles/cards/EnqueueVisitors.js
@@ -13,16 +13,21 @@ module.exports = class EnqueueVisitors extends Card{
                     if (this.game.getStateName() != "Night")
                         return;
 
-                    for (let action of this.game.actions[0])
-                        if (
-                            action.target == this.actor &&
-                            !action.hasLabel("hidden")
-                        ) {
-                            if (!this.actor.role.data.visitors)
-                                this.actor.role.data.visitors = [];
-
-                            this.actor.role.data.visitors.push(action.actor);
+                    for (let action of this.game.actions[0]) {
+                        let toCheck = action.target;
+                        if (!Array.isArray(action.target)) {
+                            toCheck = [action.target];
                         }
+            
+                        for (let target of toCheck) {
+                            if (target == this.actor && !action.hasLabel("hidden")) {
+                                if (!this.actor.role.data.visitors)
+                                    this.actor.role.data.visitors = [];
+
+                                this.actor.role.data.visitors.push(action.actor);
+                            }
+                        }
+                    }
                 }
             }
         ]


### PR DESCRIPTION
Currently we check for visitors using both getVisitors (LM, forager) and enqueueVisitors (granny)

I've checked that justice/ cop can appear as a visit to both these types of roles