### PR TITLE
quickfix: allow crier to cry during overturn meeting

### DIFF
--- a/Games/types/Mafia/roles/cards/BroadcastMessage.js
+++ b/Games/types/Mafia/roles/cards/BroadcastMessage.js
@@ -4,6 +4,25 @@ module.exports = class BroadcastMessage extends Card {
 
     constructor(role) {
         super(role);
+
+        this.listeners = {
+            "state": function (stateInfo) {
+                if (!stateInfo.name.match(/Overturn/)) {
+                    return
+                }
+
+                for (let item of this.player.items) {
+                    if (item.name == "OverturnSpectator") {
+                        item.meetings["Overturn Vote"].speechAbilities = [{
+                            name: "Cry",
+                            targets: ["out"],
+                            targetType: "out",
+                            verb: ""
+                        }]
+                    }
+                }
+            }
+        }
     }
 
     speak(message) {
@@ -16,4 +35,5 @@ module.exports = class BroadcastMessage extends Card {
         message.prefix = "cries out";
         message.recipients = message.game.players;
     }
+
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24848927/226654104-5bc9ddca-b56d-4b30-80ea-64c7cab33a3d.png)

- this is a quickfix to allow cry oh to be played
- the correct solution should be to apply meeting mods to items, #529 