### PR TITLE
feat: check plurality for meetings

### DIFF
--- a/Games/core/Meeting.js
+++ b/Games/core/Meeting.js
@@ -825,7 +825,7 @@ module.exports = class Meeting {
             return selections.length >= this.multiMin || selections.indexOf("*") != -1;
         }
     }
-    
+
     // Checks whether the meeting has a plurality target.
     get hasPlurality() {
         var count = {};
@@ -840,9 +840,9 @@ module.exports = class Meeting {
 
             count[target] += member.voteWeight;
         }
-
-        sortedCount = Object.entries(count).sort((a,b) => {return b[1] - a[1]});
-        // Checking for plurality.
+        let sortedCount = Object.entries(count).sort((a,b) => {return b[1] - a[1]});
+        
+        // Checking for plurality
         if (sortedCount.length === 1 || sortedCount[0][1] > sortedCount[1][1])
             return true;
         return false;


### PR DESCRIPTION
Most of the code was looted from @Kaltzisp #259 

The count votes part is taken from another part of Meeting.js where the votes are resolved.

Closes #170 

- accounts for vote weights
- accounts for king --> always has plurality

https://user-images.githubusercontent.com/24848927/226692367-dd12b923-d6bb-4bdb-95ae-a0c33d818d3d.mp4



