### PR TITLE
Remove birthday purchase & remove year kinda?

### DIFF
--- a/db/schemas.js
+++ b/db/schemas.js
@@ -49,7 +49,6 @@ var schemas = {
             textColors: { type: Number, default: 0 },
             customProfile: { type: Number, default: 0 },
             nameChange: { type: Number, default: 1 },
-            bdayChange: { type: Number, default: 1 },
             emotes: { type: Number, default: 0 },
             threeCharName: { type: Number, default: 0 },
             twoCharName: { type: Number, default: 0 },

--- a/react_main/src/components/Form.jsx
+++ b/react_main/src/components/Form.jsx
@@ -214,6 +214,7 @@ export default function Form(props) {
 				else {
 					currentValue = new Date(field.value);
 				}
+				var currentYear = new Date().getFullYear();
 				return (
 					<div className={fieldWrapperClass} key={field.ref}>
 						<div className="label">
@@ -227,9 +228,10 @@ export default function Form(props) {
 							nativeInputAriaLabel="Date"
 							onChange={e => onDChange(e, field, true)}
 							value={currentValue}
-							default={subtractYears(new Date(), 13)}
-							yearAriaLabel="Year"
-							maxDate={subtractYears(new Date(), 13)}
+							default={new Date()}
+							maxDetail="month"
+							maxDate={new Date(currentYear, 11, 31)}
+							minDate={new Date(currentYear, 0, 1)}
 						/>
 						{field.saveBtn &&
 						 Date.parse(props.deps.user[field.saveBtnDiffer]) 
@@ -283,11 +285,6 @@ export default function Form(props) {
 			}
 		</div>
 	);
-}
-
-function subtractYears(date, years) {
-	date.setFullYear(date.getFullYear() - years);
-	return date;
 }
 
 function Switch(props) {

--- a/react_main/src/pages/User/Settings.jsx
+++ b/react_main/src/pages/User/Settings.jsx
@@ -233,12 +233,7 @@ export default function Settings(props) {
 				deps.siteInfo.showAlert("Birthday set", "success");
 
 				deps.user.set(update(deps.user, {
-					birthday: { $set: date },
-					itemsOwned: {
-						bdayChange: {
-							$set: deps.user.itemsOwned.bdayChange - 1
-						}
-					}
+					birthday: { $set: date }
 				}));
 			})
 			.catch(deps.errorAlert);

--- a/routes/shop.js
+++ b/routes/shop.js
@@ -37,16 +37,6 @@ const shopItems = [
         }
     },
     {
-        name: "Birthday Change",
-        desc: "Change your birthday once per purchase",
-        key: "bdayChange",
-        price: 10,
-        limit: null,
-        onBuy: function () {
-            
-        }
-    },
-    {
         name: "3 Character Username",
         desc: "Set your name to one that is 3 characters long",
         key: "threeCharName",

--- a/routes/user.js
+++ b/routes/user.js
@@ -591,17 +591,10 @@ router.post("/birthday", async function (req, res){
         }
         let value = String(req.body.date);
 
-        if (!itemsOwned.bdayChange) {
-            res.status(500);
-            res.send("You must purchase another birthday change from the Shop.");
-            return;
-        }
-
         await models.User.updateOne(
             { id: userId },
             {
-                $set: { birthday: value, bdayChanged: true },
-                $inc: { "itemsOwned.bdayChange": -1 }
+                $set: { birthday: value, bdayChanged: true }
             }
         ).exec();
         await redis.cacheUserInfo(userId, true);


### PR DESCRIPTION
I wasn't able to find a way to remove the year detail. I opened a discussion on the repo for the management of the date picker node module. The most I could think to do was to make the minDate = Jan 1st, current year, and then maxDate = Dec 31st, current year.
Secondly, I just removed the limitations on the birthday changes and removed purchasing, etc.