### PR TITLE
bugfix(thulu, watcher): use getVisitors to properly check for hidden visitors and multimeeting visitors

### DIFF
--- a/Games/types/Mafia/Action.js
+++ b/Games/types/Mafia/Action.js
@@ -32,7 +32,7 @@ module.exports = class MafiaAction extends Action {
             }
 
             for (let target of toCheck) {
-                if (target == this.actor && !action.hasLabel("hidden")) {
+                if (target === player && !action.hasLabel("hidden")) {
                     visitors.push(action.actor);
                 }
             }

--- a/Games/types/Mafia/roles/cards/MakeVisitorsInsane.js
+++ b/Games/types/Mafia/roles/cards/MakeVisitorsInsane.js
@@ -11,13 +11,14 @@ module.exports = class MakeVisitorsInsane extends Card {
                 priority: PRIORITY_EFFECT_GIVER_DEFAULT,
                 labels: ["hidden", "absolute"],
                 run: function () {
-                    if (this.game.getStateName() == "Night") {
-                        for (let action of this.game.actions[0]) {
-                            if (action.target == this.actor && !action.hasLabel("hidden")) {
-                                action.actor.giveEffect("Insanity");
-                                action.actor.queueAlert(":sy3f: Reality fades as your mind is consumed by insanity.");
-                            }
-                        }
+                    if (this.game.getStateName() !== "Night") {
+                        return
+                    }
+
+                    let visitors = this.getVisitors();
+                    for (let visitor of visitors) {
+                        visitor.giveEffect("Insanity");
+                        visitor.queueAlert(":sy3f: Reality fades as your mind is consumed by insanity.");
                     }
                 }
             }

--- a/Games/types/Mafia/roles/cards/WatchPlayer.js
+++ b/Games/types/Mafia/roles/cards/WatchPlayer.js
@@ -15,22 +15,14 @@ module.exports = class WatchPlayer extends Card {
                     labels: ["investigate", "hidden"],
                     priority: PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT,
                     run: function () {
-                        var visits = [];
 
-                        for (let action of this.game.actions[0]) {
-                            if (
-                                action.target == this.target &&
-                                !action.hasLabel("hidden") &&
-                                action.priority < this.priority
-                            ) {
-                                visits.push(action.actor.name);
-                            }
+                        let visitors = this.getVisitors(this.target);
+                        let visitorNames = visitors.map(player => player.name);
+                        if (visitorNames.length === 0) {;
+                            visitorNames.push("no one");
                         }
 
-                        if (visits.length == 0)
-                            visits.push("no one");
-
-                        this.actor.queueAlert(`:sy0f: ${this.target.name} was visited by ${visits.join(", ")} during the night.`);
+                        this.actor.queueAlert(`:sy0f: ${this.target.name} was visited by ${visitorNames.join(", ")} during the night.`);
                     }
                 }
             }

--- a/Games/types/Mafia/roles/cards/WatchPlayer.js
+++ b/Games/types/Mafia/roles/cards/WatchPlayer.js
@@ -12,6 +12,7 @@ module.exports = class WatchPlayer extends Card {
                 flags: ["voting"],
                 targets: { include: ["alive"], exclude: [] },
                 action: {
+                    labels: ["investigate", "hidden"],
                     priority: PRIORITY_INVESTIGATIVE_AFTER_RESOLVE_DEFAULT,
                     run: function () {
                         var visits = [];


### PR DESCRIPTION
Fixes #539 

thulu 
- [x] does not make watcher (hidden) insane
- [x] makes justice (multimeeting) insane
- [x] makes cop (normal visitor) insane  

watcher
- [x] able to detect cop
- [x] able to detect justice
- [x] check system message for 0, 1 and 2 people

**roles - egg = cop, nabila = thulu, markson = watcher, aimee = justice**

![image](https://user-images.githubusercontent.com/24848927/228017253-57c1b54e-7725-4e44-9f58-d0f6092513b4.png)

![image](https://user-images.githubusercontent.com/24848927/228017290-b9076e5f-8fd2-4710-bd70-4238c6bb817e.png)

![image](https://user-images.githubusercontent.com/24848927/228017328-bd5805a4-eabb-4b2f-b2a7-e81b36b1a185.png)
