### PR TITLE
bugfix: tree does not copy sapling modifiers

### DIFF
--- a/Games/types/Mafia/roles/cards/TurnIntoTree.js
+++ b/Games/types/Mafia/roles/cards/TurnIntoTree.js
@@ -15,7 +15,7 @@ module.exports = class TurnIntoTree extends Card {
                     priority: PRIORITY_NIGHT_SAVER,
                     run: function () {
                         if (this.target === "Yes"){
-                            this.actor.setRole(`Tree:${this.actor.role.modifier}`, this.actor.role.data, true, false);
+                            this.actor.setRole(`Tree`, this.actor.role.data, true);
                             this.actor.queueAlert(":sy2e: You grow into a tree!");
                         }
                     }


### PR DESCRIPTION
most modifiers don't apply to tree...
we can also add a manual check for "start with" modifiers

Fixes #588 