### PR TITLE
Alert size and position fixed

### DIFF
--- a/react_main/src/css/alerts.css
+++ b/react_main/src/css/alerts.css
@@ -21,9 +21,13 @@
     align-items: center;
 
     width: 50vw;
+    max-width: fit-content;
 
     margin-bottom: 10px;
     padding: 5px;
+    margin-left: 55px;
+    padding-left: 24px;
+    padding-right: 24px;
 
     background-color: var(--theme-color);
     color: white;

--- a/react_main/src/css/main.css
+++ b/react_main/src/css/main.css
@@ -76,6 +76,7 @@ a {
     width: 1000px;
     max-width: 100%;
     padding: 20px;
+    margin-top: 30px;
 }
 
 .header {


### PR DESCRIPTION
For real now: I edited the css of the alert and the overall page so that the alerts aren't in the way and in an awkward manner.

Alerts now have a max size comparable to the text they have inside, and the banner (and everything below) is a couple pixels lower so that the alert doesn't cover anything important.