### PR TITLE
feat(snoop): add role items and item descriptions

### DIFF
--- a/Games/types/Mafia/Action.js
+++ b/Games/types/Mafia/Action.js
@@ -107,4 +107,33 @@ module.exports = class MafiaAction extends Action {
             }
         }
     }
+
+    snoopAllItems(victim, excludeRoleItems) {
+        victim = victim || this.target;
+
+        let items = [];
+        for (let item of this.target.items) {
+            if (item.cannotBeSnooped) {
+                continue;
+            }
+
+            items.push("a " + item.snoopName);
+        }
+
+        if (excludeRoleItems) {
+            return items;
+        }
+
+        switch (victim.role.name) {
+            case "Mason":
+            case "Cultist":
+                items.push("a Robe");
+                break;
+            case "Janitor":
+                items.push("a Mop");
+                break
+        }
+
+        return items;
+    }
 }

--- a/Games/types/Mafia/Item.js
+++ b/Games/types/Mafia/Item.js
@@ -6,4 +6,7 @@ module.exports = class MafiaItem extends Item {
         super(name, data);
     }
 
+    get snoopName() {
+        return this.name;
+    }
 };

--- a/Games/types/Mafia/items/Gun.js
+++ b/Games/types/Mafia/items/Gun.js
@@ -59,4 +59,13 @@ module.exports = class Gun extends Item {
         };
     }
 
+    get snoopName() {
+        if (this.mafiaImmune) {
+            return "Gun (Associate)"
+        } else if (this.cursed) {
+            return "Gun (Cursed)"
+        }
+
+        return this.name;
+    }
 }

--- a/Games/types/Mafia/items/Suit.js
+++ b/Games/types/Mafia/items/Suit.js
@@ -16,4 +16,8 @@ module.exports = class Suit extends Item {
 
         super.hold(player);
     }
+
+    get snoopName() {
+        return `Suit (${this.type})`
+    }
 }

--- a/Games/types/Mafia/roles/cards/SnoopItems.js
+++ b/Games/types/Mafia/roles/cards/SnoopItems.js
@@ -13,14 +13,7 @@ module.exports = class SnoopItems extends Card {
                 action: {
                     priority: PRIORITY_INVESTIGATIVE_DEFAULT,
                     run: function () {
-                        let items = [];
-                        for (let item of this.target.items) {
-                            if (item.cannotBeSnooped) {
-                                continue;
-                            }
-
-                            items.push("a " + item.name);
-                        }
+                        let items = this.snoopAllItems()
                         items.sort();
 
                         let itemsToAlert = "nothing"

--- a/react_main/src/pages/Play/Learn/LearnMafia.jsx
+++ b/react_main/src/pages/Play/Learn/LearnMafia.jsx
@@ -24,7 +24,7 @@ export default function LearnMafia(props) {
 		},
 		{
 			name: "Crystal",
-			text: "The holder of the crystal can choose a person each night and if they die, their targets role will be revealed.",
+			text: "The holder of the crystal can choose a person each night and if they die, their target's role will be revealed.",
 		},
 		{
 			name: "Knife",
@@ -32,7 +32,7 @@ export default function LearnMafia(props) {
 		},
 		{
 			name: "Snowball",
-			text: "Can be used once during the day to freeze a specific player, who will be role blocked the following night.",
+			text: "Can be used once during the day to freeze a specific player, who will be roleblocked the following night.",
 		},
 		{
 			name: "Bread",
@@ -48,7 +48,7 @@ export default function LearnMafia(props) {
 		},
 		{
 			name: "Gasoline",
-			text: "Used by the arsonist to douse their victims in preparation of the great town BBQ.",
+			text: "Used by the arsonist to douse their victims in preparation for their ignition.",
 		},
 		{
 			name: "Match",

--- a/react_main/src/pages/Play/Learn/LearnMafia.jsx
+++ b/react_main/src/pages/Play/Learn/LearnMafia.jsx
@@ -26,6 +26,38 @@ export default function LearnMafia(props) {
 			name: "Crystal",
 			text: "The holder of the crystal can choose a person each night and if they die, their targets role will be revealed.",
 		},
+		{
+			name: "Knife",
+			text: "Can be used once during the day to stab a specific player, who will bleed out and die the following night.",
+		},
+		{
+			name: "Snowball",
+			text: "Can be used once during the day to freeze a specific player, who will be role blocked the following night.",
+		},
+		{
+			name: "Crystal",
+			text: "At night, the crystal ball can be enchanted with a target's name. When the holder dies, the target's role is revealed.",
+		},
+		{
+			name: "Baker",
+			text: "Given out by the baker. Counts as 1 ration for each phase in a famine.",
+		},
+		{
+			name: "Yuzu Orange",
+			text: "Given out by the Capybara to invite players to relax at the hot springs. Counts as 1 ration for each phase in a famine.",
+		},
+		{
+			name: "Suit",
+			text: "Given by the tailor, a suit determines what role a user will appear as once dead.",
+		},
+		{
+			name: "Gasoline",
+			text: "Used by the arsonist to douse their victims in preparation of the great town BBQ.",
+		},
+		{
+			name: "Match",
+			text: "Used by the arsonist to ignite the great town BBQ.",
+		},
 	];
 
 	var mechanics = [

--- a/react_main/src/pages/Play/Learn/LearnMafia.jsx
+++ b/react_main/src/pages/Play/Learn/LearnMafia.jsx
@@ -35,11 +35,7 @@ export default function LearnMafia(props) {
 			text: "Can be used once during the day to freeze a specific player, who will be role blocked the following night.",
 		},
 		{
-			name: "Crystal",
-			text: "At night, the crystal ball can be enchanted with a target's name. When the holder dies, the target's role is revealed.",
-		},
-		{
-			name: "Baker",
+			name: "Bread",
 			text: "Given out by the baker. Counts as 1 ration for each phase in a famine.",
 		},
 		{
@@ -56,7 +52,7 @@ export default function LearnMafia(props) {
 		},
 		{
 			name: "Match",
-			text: "Used by the arsonist to ignite the great town BBQ.",
+			text: "Used by the arsonist to ignite everyone doused with gasoline.",
 		},
 	];
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24848927/229341856-94e610a2-9c85-499d-a666-497014a86692.png)

- moved snoop action to library
- allow snooping role items like mop for janitor and robe for mason/ cult
- allow snooping specific gun and suit type
- added descriptions to learn tab

Fixes #221 
Fixes #468 