### PR TITLE
Add lover success message for lover

### DIFF
--- a/Games/types/Mafia/roles/cards/BondedForLife.js
+++ b/Games/types/Mafia/roles/cards/BondedForLife.js
@@ -16,6 +16,9 @@ module.exports = class BondedForLife extends Card {
                         this.actor.role.data.loves = this.target;
                         let alert = `:sy3g: You fall deathly in love with ${this.actor.name}.`;
                         this.target.queueAlert(alert);
+
+                        let selfAlert = `:sy3g: You fall deathly in love with ${this.target.name}.`;
+                        this.actor.queueAlert(selfAlert);
                     }
                 },
                 shouldMeet() {


### PR DESCRIPTION
Issue: https://github.com/r3ndd/BeyondMafia-Integration/issues/616

@DrSharky - Obviously let me know if there's better ways to do it than what I just did, which is following what I saw.

1. Add test to ensure both Lover and its target will get message.
2. Add new alert to queue for the actor.

