### PR TITLE
Make dark/light theme UX better

### DIFF
--- a/react_main/src/Main.jsx
+++ b/react_main/src/Main.jsx
@@ -44,8 +44,18 @@ function Main() {
             .catch(errorAlert);
     }
 
-    const userColourScheme = user.settings?.siteColorScheme || "light";
+    var userColourScheme = "";
 
+    if (user.settings?.siteColorScheme === false) {
+        userColourScheme = "light";
+    }
+    else if (user.settings.siteColorScheme === true) {
+        userColourScheme = "dark";
+    }
+    else {
+        userColourScheme = user.settings?.siteColorScheme || "auto";
+    }
+    
     if (userColourScheme === "light") {
         if (document.documentElement.classList.contains("dark-mode")) {
             document.documentElement.classList.remove("dark-mode");


### PR DESCRIPTION
The schema is changing from boolean to string, so I tried to compensate for that. If the "siteColorScheme" setting is set to true in DB, it will display dark theme still. Likewise, if set to false, it will display light theme. Honestly it looks like it still worked fine regardless, but put in these checks to make sure. Also, defaulting to auto setting for best UX.