### PR TITLE
fix: profanity filter no longer replaces numbers

### DIFF
--- a/react_main/src/json/swears.js
+++ b/react_main/src/json/swears.js
@@ -1,9 +1,18 @@
 export default [
+    "ass",
     "asshole",
     "bitch",
+    "bitches",
+    "cock",
     "cunt",
     "dick",
     "fuck",
+    "fucked",
+    "fucking",
+    "pussy",
     "shit",
+    "slut",
+    "tit",
+    "wanker",
     "whore",
 ]

--- a/react_main/src/lib/profanity.js
+++ b/react_main/src/lib/profanity.js
@@ -64,27 +64,24 @@ function filterProfanitySegment(profanityType, segment, char) {
             return segment;
     }
 
-    let originalSegment = segment;
     // Substituting numbers with letters.
+    let mappedSegment = segment;
     for (const num in leetMappings) {
-        segment = segment.replace(num, leetMappings[num]);
+        mappedSegment = mappedSegment.replaceAll(num, leetMappings[num]);
     }
 
-    let segmentBeforeFilter = segment;
     // Filtering profanity.
     for (const profanityRegex of profanityRegexps) {
-        let regexRes = profanityRegex.exec(segment);
+        let regexRes = profanityRegex.exec(mappedSegment);
         while (regexRes) {
             // regexRes.index returns the index of the start of the match, not the capturing group.
             const index = regexRes.index + regexRes[0].indexOf(regexRes[1]);
             const length = regexRes[1].length;
             segment = segment.slice(0, index) + char.repeat(length) + segment.slice(index + length);
-            regexRes = profanityRegex.exec(segment);
+            // Filtering mappedSegment, to ensure that segments match.
+            mappedSegment = mappedSegment.slice(0, index) + char.repeat(length) + mappedSegment.slice(index + length);
+            regexRes = profanityRegex.exec(mappedSegment);
         }
-    }
-
-    if (segment == segmentBeforeFilter) {
-        segment = originalSegment
     }
     return segment;
 }


### PR DESCRIPTION
- Fixes #737 
- Also added some common swears to `swears.json`
![image](https://user-images.githubusercontent.com/31025213/233514289-792aeb0a-2f4f-4307-8708-edd654c09668.png)
![image](https://user-images.githubusercontent.com/31025213/233514301-2119e4d2-44fb-4316-8ace-a424f00d62c7.png)
