### PR TITLE
Adjust Colors based on contrast

### DIFF
--- a/react_main/package.json
+++ b/react_main/package.json
@@ -6,6 +6,7 @@
     "agora-rtc-sdk-ng": "^4.15.0",
     "axios": "^0.19.2",
     "color": "^3.1.2",
+    "color-contrast": "^1.0.0",
     "firebase": "^9.14.0",
     "immutability-helper": "^3.0.2",
     "react": "^16.13.1",

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -277,6 +277,30 @@
 	white-space: pre-wrap;
 }
 
+.game .message .content.dark {
+	filter: brightness(70%);
+}
+
+.game .message .content.darker {
+	filter: brightness(60%);
+}
+
+.game .message .content-darkest {
+	filter: brightness(50%);
+}
+
+.game .message .content-bright {
+	filter: brightness(130%)
+}
+
+.game .message .content.brighter {
+	filter: brightness(145%);
+}
+
+.game .message .content.brightest {
+	filter: brightness(160%);
+}
+
 .game .message .content.greentext {
 	color: #789922
 }

--- a/react_main/src/css/user.css
+++ b/react_main/src/css/user.css
@@ -164,6 +164,29 @@ iframe {
     display: flex;
 }
 
+.user-name.dark {
+    filter: brightness(70%)
+}
+
+.user-name.darker {
+    filter: brightness(60%)
+}
+.user-name.darkest {
+    filter: brightness(50%);
+}
+
+.user-name.bright {
+    filter: brightness(130%);
+}
+
+.user-name.brighter {
+    filter: brightness(145%);
+}
+
+.user-name.brightest {
+    filter: brightness(160%);
+}
+
 .profile .user-info {
     flex-grow: 1;
 

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -24,7 +24,7 @@ import { MaxGameMessageLength, MaxTextInputLength, MaxWillLength } from "../../C
 import { textIncludesSlurs } from "../../lib/profanity";
 
 import "../../css/game.css";
-import { flipTextColor, hexToHSL, HSLToHex, HSLToHexString, RGBToHSL } from "../../utils";
+import { adjustColor, flipTextColor } from "../../utils";
 
 export default function Game() {
     return (
@@ -1200,6 +1200,10 @@ function Message(props) {
 
     if (message.content?.startsWith(">")) {
         contentClass += "greentext ";
+    }
+
+    if (player !== undefined && player.textColor !== undefined) {
+        contentClass += `${adjustColor(player.textColor)}`;
     }
     
     return (

--- a/react_main/src/pages/User/User.jsx
+++ b/react_main/src/pages/User/User.jsx
@@ -10,7 +10,7 @@ import { SubNav } from "../../components/Nav";
 import { HiddenUpload } from "../../components/Form";
 
 import "../../css/user.css"
-import { flipTextColor } from "../../utils";
+import { adjustColor, flipTextColor } from "../../utils";
 
 
 export function YouTubeEmbed(props) {
@@ -147,6 +147,8 @@ export function NameWithAvatar(props) {
 
 	const popover = useContext(PopoverContext);
 
+	var userNameClassName = `user-name ${adjustColor(color)}`;
+
 	return (
 		<Link
 			className={`name-with-avatar ${noLink ? "no-link" : ""}`}
@@ -164,7 +166,7 @@ export function NameWithAvatar(props) {
 				name={name}
 				small={small}
 				active={active} />
-			<div className="user-name" style={color ? { color: flipTextColor(color) } : {}}>{name}</div>
+			<div className={userNameClassName} style={color ? { color: flipTextColor(color) } : {}}>{name}</div>
 			{groups &&
 				<Badges groups={groups} small={small} />
 			}

--- a/react_main/src/utils.jsx
+++ b/react_main/src/utils.jsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import colorContrast from "color-contrast";
 
 export function hyphenDelimit(roleName) {
 	roleName = roleName.slice();
@@ -106,13 +107,10 @@ export function capitalize(string) {
 	return "#" + r + g + b;
   }
 
-  export function flipTextColor(hexColor){
-	let hslColor = hexToHSL(hexColor);
-	let hslVals = hslColor.split(',');
-	let h = hslVals[0], s = hslVals[1], l = hslVals[2];
-
-	var colorScheme = "light";
-	var colorAutoScheme = false;
+  export function adjustColor(hexColor) {
+	let contrastVal = 0;
+	let colorScheme = "light"
+	let colorAutoScheme = false;
 	if (document.documentElement.classList.length === 0) {
 		colorAutoScheme = true;
 	}
@@ -133,6 +131,61 @@ export function capitalize(string) {
 		}
 	}
 
+	if (colorScheme === "light") {
+		contrastVal = colorContrast(hexColor, "#ffffff");
+		if (contrastVal < 1.5) {
+			return "darkest";
+		} 
+		else if(contrastVal <= 2.5) {
+			return "darker";
+		}
+		else if (contrastVal <= 4.5) {
+			return "dark";
+		}
+	}
+	else {
+		contrastVal = colorContrast(hexColor, "#181a1b");
+		if (contrastVal < 1.5) {
+			return "brightest";
+		}
+		else if (contrastVal <= 2.5) {
+			return "brighter"
+		}
+		else if (contrastVal <= 4.5) {
+			return "bright";
+		}
+	}
+	return "";
+  }
+
+
+  export function flipTextColor(hexColor) {
+	let contrastVal = 0;
+	let hslColor = hexToHSL(hexColor);
+	let hslVals = hslColor.split(',');
+	let h = hslVals[0], s = hslVals[1], l = hslVals[2];
+
+	let colorScheme = "light";
+	let colorAutoScheme = false;
+	if (document.documentElement.classList.length === 0) {
+		colorAutoScheme = true;
+	}
+	else {
+		if (!document.documentElement.classList.contains("light-mode")) {
+			if (!document.documentElement.classList.contains("dark-mode")) {
+				colorAutoScheme = true;
+			}
+			else {
+				colorScheme = "dark";
+			}
+		}
+	}
+
+	if (colorAutoScheme) {
+		if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+			colorScheme = "dark";
+		}
+	}
 
 	if (l > 70 && colorScheme === "light") {
 		var difference = l - 70;


### PR DESCRIPTION
Added NPM package for color contrast ratio calculation. Add brightness filter to user-selected color text based on the ratio calculation, darker/brighter depending on the difference.

Will close #724.