### PR TITLE
Disguiser Bug: Use correct userID to delete from redis

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -437,6 +437,9 @@ module.exports = class Game {
             }
         }
 
+        // In the event of a guiser swap, the userId that is needed to leave is
+        // the target. However, the `player` in this game is the still alive disguiser
+        // Therefore, if the swapped user is not null, then we need to use that person's ID
         let userIdToLeave = player.user.id;
         if (player.user.swapped) {
             userIdToLeave = player.user.swapped.id;

--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -437,7 +437,11 @@ module.exports = class Game {
             }
         }
 
-        await redis.leaveGame(player.user.id);
+        let userIdToLeave = player.user.id;
+        if (player.user.swapped) {
+            userIdToLeave = player.user.swapped.id;
+        }
+        await redis.leaveGame(userIdToLeave);
     }
 
     async onAllPlayersLeft() {


### PR DESCRIPTION
Original Issue: When the guiser target leaves game, they are able to leave successfully from game. However, from lobby, they are prompted with "still in game" situation and when they press to leave game there, it kicks the disguiser out as well.

Solution: Ensure that when leaving a game, the redis cache that holds active games for a user is cleared using the correct user ID and not the userID of the swapped.

Risk Factor: Low - this should only be in affect when swapped is called into question. All other code paths and flows will be unaffected.