### PR TITLE
player cannot be jailed/seanced

### DIFF
--- a/Games/types/Mafia/roles/cards/JailTarget.js
+++ b/Games/types/Mafia/roles/cards/JailTarget.js
@@ -27,6 +27,11 @@ module.exports = class JailTarget extends Card {
                     labels: ["jail"],
                     priority: PRIORITY_DAY_DEFAULT,
                     run: function () {
+                        if (this.target.hasItem("Handcuffs")){
+                            this.actor.queueAlert(`You try and jail ${this.target.name} but you can't find them!`);
+                            return;
+                        }
+
                         if (this.dominates()) {
                             this.target.holdItem("Handcuffs", this.actor.role.data.meetingName);
                             this.actor.role.data.prisoner = this.target;

--- a/Games/types/Mafia/roles/cards/SeanceTarget.js
+++ b/Games/types/Mafia/roles/cards/SeanceTarget.js
@@ -28,6 +28,11 @@ module.exports = class SeanceTarget extends Card {
                     labels: ["seance"],
                     priority: PRIORITY_DAY_DEFAULT,
                     run: function () {
+                        if (this.target.hasItem("Summon")){
+                            this.actor.queueAlert(`You try and seance ${this.target.name} but you don't find them in the graveyard!`);
+                            return;
+                        }
+
                         if (this.dominates()) {
                             this.target.holdItem("Summon", this.actor.role.data.meetingName);
                         }


### PR DESCRIPTION
inspired by a bug where two people kept seancing the same person, the seanced player wasn't able to talk. this should fix that bug.

only problem is that currently, I believe that the person who gets the seance is the person who joins the game first, which could be unfair.