### PR TITLE
feat: instant meetings reset kicks [fixes reset kicks]

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1217,6 +1217,10 @@ module.exports = class Game {
         }
         
         this.sendMeetings(players);
+
+        if (this.vegKickMeeting !== undefined) {
+            this.vegKickMeeting.resetKicks();
+        }
     }
 
     isMustAct() {

--- a/Games/core/VegKickMeeting.js
+++ b/Games/core/VegKickMeeting.js
@@ -12,6 +12,9 @@ module.exports = class VegKickMeeting extends Meeting {
         this.inputType = "button";
         this.targets = ["Kick"];
         this.votesInvisible = true;
+        // when enough kicks has reached, people who have not voted can spam kick
+        // this flag prevents that
+        this.repeatable = true;
 
         this.hasFrozenOtherMeetings = false;
     }
@@ -24,9 +27,14 @@ module.exports = class VegKickMeeting extends Meeting {
 
     resetKicks() {
         this.game.clearTimer("vegKick");
-        this.votes = {};
+        this.finished = false;
 
         for (let player of this.game.players) {
+            // unvote
+            this.members[player.id].canUnvote = true;
+            this.unvote(this.members[player.id], this.votes[player.id]);
+            this.members[player.id].canUnvote = false;
+
             if (!player.alive) {
                 continue
             }
@@ -96,6 +104,7 @@ module.exports = class VegKickMeeting extends Meeting {
         let vegKickThreshold = Math.ceil(numAlive / 3);
 
         let numKicked = Object.keys(this.votes).length;
+        numKicked = Math.min(numKicked, vegKickThreshold);
         this.game.sendAlert(`Kicking... ${numKicked} / ${vegKickThreshold}`);
         return [numKicked, vegKickThreshold]
     }

--- a/Games/types/Mafia/roles/cards/ProposeMarriage.js
+++ b/Games/types/Mafia/roles/cards/ProposeMarriage.js
@@ -8,7 +8,7 @@ module.exports = class ProposeMarriage extends Card {
         this.meetings = {
             "Propose": {
                 states: ["Day"],
-                flags: ["voting", "instant", "noVeg"],
+                flags: ["voting", "instant"],
                 shouldMeet: function() {
                     return !this.isMarried;
                 },


### PR DESCRIPTION
Fixes #785 
Fixes #774 

**starting the instant meeting resets kicks**
- [x] proposing resets kicks
- [x] accepting the proposal (finishing the instant meeting) does not reset kicks
- [x] after accepting the proposal, the target can kick

**made bride meeting veggable**

**fixed the kicking 2/2 spam we saw yesterday** 