### PR TITLE
feat: add gunslinger and sharpshooter

### DIFF
--- a/Games/types/Mafia/items/Gun.js
+++ b/Games/types/Mafia/items/Gun.js
@@ -22,6 +22,9 @@ module.exports = class Gun extends Item {
                     labels: ["kill", "gun"],
                     item: this,
                     run: function () {
+                        this.item.drop();
+                        this.game.broadcast("gunshot");
+
                         var shooterMask = this.actor.role.data.shooterMask;
                         var reveal = shooterMask ? true : this.item.reveal;
                         if (reveal == null) {
@@ -53,9 +56,6 @@ module.exports = class Gun extends Item {
                         if (toKill) {
                             this.target.kill("gun", this.actor, true);
                         }
-
-                        this.item.drop();
-                        this.game.broadcast("gunshot");
                     }
                 }
             }
@@ -86,9 +86,9 @@ module.exports = class Gun extends Item {
 
     // increase meeting name index to ensure each meeting name is unique
     incrementMeetingName() {
-        let mtg = this.item.meetings[this.item.getCurrentMeetingName()]
-        delete this.item.meetings[this.item.getCurrentMeetingName()]
+        let mtg = this.meetings[this.getCurrentMeetingName()]
+        delete this.meetings[this.getCurrentMeetingName()]
         this.currentMeetingIndex += 1
-        this.item.meetings[this.item.getCurrentMeetingName()] = mtg;
+        this.meetings[this.getCurrentMeetingName()] = mtg;
     }
 }

--- a/Games/types/Mafia/roles/Mafia/Sharpshooter.js
+++ b/Games/types/Mafia/roles/Mafia/Sharpshooter.js
@@ -1,0 +1,11 @@
+const Role = require("../../Role");
+
+module.exports = class Sharpshooter extends Role {
+
+    constructor(player, data) {
+        super("Sharpshooter", player, data);
+        this.alignment = "Mafia";
+        this.cards = ["VillageCore", "WinWithMafia", "MeetingMafia", "DefendAndSnatchGun"];
+    }
+
+}

--- a/Games/types/Mafia/roles/Village/Gunslinger.js
+++ b/Games/types/Mafia/roles/Village/Gunslinger.js
@@ -1,0 +1,11 @@
+const Role = require("../../Role");
+
+module.exports = class Gunslinger extends Role {
+
+    constructor(player, data) {
+        super("Gunslinger", player, data);
+        this.alignment = "Village";
+        this.cards = ["VillageCore", "WinWithVillage", "DefendAndSnatchGun"];
+    }
+
+}

--- a/Games/types/Mafia/roles/cards/DefendAndSnatchGun.js
+++ b/Games/types/Mafia/roles/cards/DefendAndSnatchGun.js
@@ -1,0 +1,30 @@
+const Card = require("../../Card");
+
+module.exports = class DefendAndSnatchGun extends Card {
+
+    constructor(role) {
+        super(role);
+
+        this.immunity["gun"] = "Infinity";
+        this.listeners = {
+            "immune": function(action) {
+                if (action.target !== this.player) {
+                    return
+                }
+
+                let toSnatch = Random.randFloatRange(0, 100) <= 80;
+                if (toSnatch) {
+                    action.item.hold(this.target);
+                    action.item.incrementMeetingName();
+                    this.game.instantMeeting(this.item.meetings, [this.target]);
+                    return;
+                }
+
+                // kill player
+                delete this.player.role.immunity["gun"]
+                this.player.kill("gun", action.actor, true);
+            }
+        };
+    }
+
+}

--- a/Games/types/Mafia/roles/cards/DefendAndSnatchGun.js
+++ b/Games/types/Mafia/roles/cards/DefendAndSnatchGun.js
@@ -1,4 +1,5 @@
 const Card = require("../../Card");
+const Random = require("../../../../../lib/Random");
 
 module.exports = class DefendAndSnatchGun extends Card {
 
@@ -14,9 +15,9 @@ module.exports = class DefendAndSnatchGun extends Card {
 
                 let toSnatch = Random.randFloatRange(0, 100) <= 80;
                 if (toSnatch) {
-                    action.item.hold(this.target);
+                    action.item.hold(this.player);
                     action.item.incrementMeetingName();
-                    this.game.instantMeeting(this.item.meetings, [this.target]);
+                    this.game.instantMeeting(action.item.meetings, [this.player]);
                     return;
                 }
 

--- a/data/roles.js
+++ b/data/roles.js
@@ -573,6 +573,12 @@ const roleData = {
                 "When President dies, all villagers will die.",
                 ],
         },
+        "Gunslinger": {
+            alignment: "Village",
+            description: [
+                "When shot, has an 80% chance of surviving and stealing the gun.",
+            ],
+        },
 
         //Mafia
         "Mafioso": {
@@ -914,6 +920,12 @@ const roleData = {
             alignment: "Mafia",
             description: [
                 "Can speak as any player during the day.", 
+            ],
+        },
+        "Sharpshooter": {
+            alignment: "Mafia",
+            description: [
+                "When shot, has an 80% chance of surviving and stealing the gun.",
             ],
         },
 


### PR DESCRIPTION
the fastest way to test this role is to create setups with Gunslinger (Armed) and Sharpshooter (Armed)

- [x] stealing asso gun is still asso gun
- [x] stealing illu gun is normal gun

illu case -
--> gunn the illusionist guised as steinke
--> gunn shot eggsushi
--> eggsushi used the same gun on gunn, and it did not reveal as steinke
![image](https://user-images.githubusercontent.com/24848927/235679367-cd1dfe2d-4307-4a02-8221-4428c5a14fe1.png)
