### PR TITLE
fix(mafia): maid is able to do oneshot actions

### DIFF
--- a/Games/types/Mafia/roles/cards/OneShot.js
+++ b/Games/types/Mafia/roles/cards/OneShot.js
@@ -5,13 +5,14 @@ module.exports = class OneShot extends Card {
     constructor(role) {
         super(role);
 
+        this.metCount = {};
         this.meetingMods = {
             "*": {
                 shouldMeet: function (meetingName) {
                     if (meetingName == "Village" || meetingName == "Graveyard")
                         return true;
 
-                    return (this.data[`meets:${meetingName}`] || 0) < 1;
+                    return (this.metCount[`meets:${meetingName}`] || 0) < 1;
                 }
             }
         };
@@ -20,10 +21,10 @@ module.exports = class OneShot extends Card {
                 if (!meeting.members[this.player.id])
                     return;
 
-                if (!this.data[`meets:${meeting.name}`])
-                    this.data[`meets:${meeting.name}`] = 1;
+                if (!this.metCount[`meets:${meeting.name}`])
+                    this.metCount[`meets:${meeting.name}`] = 1;
                 else
-                    this.data[`meets:${meeting.name}`]++;
+                    this.metCount[`meets:${meeting.name}`]++;
             }
         };
     }

--- a/Games/types/Mafia/roles/cards/OneShot.js
+++ b/Games/types/Mafia/roles/cards/OneShot.js
@@ -5,7 +5,7 @@ module.exports = class OneShot extends Card {
     constructor(role) {
         super(role);
 
-        this.metCount = {};
+        role.metCount = {};
         this.meetingMods = {
             "*": {
                 shouldMeet: function (meetingName) {


### PR DESCRIPTION
Fixes #358 

i think it's a question of whether we WANT to fix this or not

The way I made it now, maided completely resets one shot state --> a one shot cop can get unlimited abilities using maid

I can toggle it such that each user can only do the one shot once, so after you're maided back the ability state is preserved (by saving data in player.data)