### PR TITLE
Changes the type used for the game titles

### DIFF
--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -31,12 +31,15 @@
 }
 
 .game .game-name {
-	font-size: 65px;
-	font-family: Spooky;
+	font-size: 75px;
+	font-family: Autophobia;
+	color: #cc0929;
+	text-shadow: 2px 3px 3px #920417;
 }
 
 .game .game-name span {
-	color: #62a0db;
+	color: #cc0929;
+	text-shadow: 2px 3px 3px #920417;
 }
 
 .game .state-wrapper {


### PR DESCRIPTION
Now uses 'Autophobia' as used in the BM Logo and site headings; in a red colour similar to that of the blood on the knife in the 'N' of the logo; drop shadow added to help add contrast and readability. Font size increased to adjust for the relative point-for-point size of 'Autophobia' and 'Spooky'.

Span text changed to be the same as the main body for the titles.

Example as in the title for 'Mafia' : https://i.gyazo.com/f2615488952daa3b77657aee8642c2a5.png

Credit to drafterman, ammico, TheBee, maxieand many others for providing helpful feedback for these changes!