### PR TITLE
Forcing username color to stay constant

### DIFF
--- a/react_main/src/css/forums.css
+++ b/react_main/src/css/forums.css
@@ -15,6 +15,7 @@
 
 .forums .user-name {
 	color: white;
+	filter: brightness(1) !important;
 }
 
 .forums .forum-nav {


### PR DESCRIPTION
Added a fix in css to force forum names to always have `filter: brightness(1)` so the color does not change.