### PR TITLE
Fullscreen setting and Game Timestamp

### DIFF
--- a/Games/core/Game.js
+++ b/Games/core/Game.js
@@ -1380,7 +1380,8 @@ module.exports = class Game {
                 voiceChat: this.voiceChat,
                 readyCheck: this.readyCheck,
                 stateLengths: this.stateLengths,
-                gameTypeOptions: JSON.stringify(this.getGameTypeOptions())
+                gameTypeOptions: JSON.stringify(this.getGameTypeOptions()),
+                createTime: this.createTime
             });
             await game.save();
 

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -170,7 +170,7 @@
 	display: flex;
 	flex-flow: row nowrap;
 	align-items: stretch;
-	justify-content: flex-start;
+	justify-content: center;
 
 	margin: 10px;
 }
@@ -190,10 +190,28 @@
 
 .game .left-panel,
 .game .right-panel {
-	width: 250px;
+  min-width: 250px;
+	width: 15%;
 }
 
 .game .center-panel {
+	display: flex;
+	flex-flow: column;
+
+  min-width: 600px;
+	width: 40%;
+	margin: 0px 10px;
+
+	background-color: transparent;
+	box-shadow: none;
+}
+
+.game .fullscreen .left-panel,
+.game .fullscreen .right-panel {
+	width: 250px;
+}
+
+.game .fullscreen .center-panel {
 	flex-grow: 1;
 	flex-basis: 0px;
 	display: flex;

--- a/react_main/src/css/game.css
+++ b/react_main/src/css/game.css
@@ -891,6 +891,16 @@
 /*
  * Media Queries
  */
+@media (max-width: 1150px) {
+	.game .left-panel,
+	.game .right-panel {
+		min-width: 200px !important;
+	}
+
+	.game .center-panel {
+		min-width: 500px !important;
+	}
+}
 
 @media (max-width: 900px) {
 	.game .main {

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -68,6 +68,7 @@ function GameWrapper(props) {
     const [deafened, setDeafened] = useState(false);
     const [rehostId, setRehostId] = useState();
     const [dev, setDev] = useState(false);
+    const [createTime, setCreateTime] = useState();
 
     const playersRef = useRef();
     const selfRef = useRef();
@@ -188,6 +189,7 @@ function GameWrapper(props) {
                         return;
                     }
 
+                    setCreateTime(data.createTime);
                     setGameType(data.type);
                     setSetup(data.setup);
 
@@ -509,6 +511,7 @@ function GameWrapper(props) {
     function getConnectionInfo() {
         axios.get(`/game/${gameId}/connect`)
             .then(res => {
+                setCreateTime(res.data.createTime);
                 setGameType(res.data.type);
                 setPort(res.data.port);
                 setToken(res.data.token || false);
@@ -646,6 +649,7 @@ function GameWrapper(props) {
             setDeafened: setDeafened,
             noLeaveRef,
             dev: dev,
+            createTime: createTime
         };
 
         return (
@@ -974,6 +978,7 @@ export function TextMeetingLayout(props) {
                 onMessageQuote={onMessageQuote}
                 settings={props.settings}
                 unfocusedMessage={unfocusedMessage}
+                gameCreateTime={game.createTime}
             />
         );
     });
@@ -1118,6 +1123,7 @@ function Message(props) {
     const players = props.players;
     const user = useContext(UserContext);
 
+    let gameCreateTime = props.gameCreateTime;
     var message = props.message;
     var player, quotedMessage;
     var contentClass = "content ";
@@ -1214,7 +1220,7 @@ function Message(props) {
         >
             <div className="sender">
                 {props.settings.timestamps &&
-                    <Timestamp time={message.time} />
+                    <Timestamp gameCreateTime={gameCreateTime} time={message.time} />
                 }
                 {player &&
                     <NameWithAvatar
@@ -1252,7 +1258,7 @@ function Message(props) {
                 {message.isQuote &&
                     <>
                         <i className="fas fa-quote-left" />
-                        <Timestamp time={quotedMessage.time} />
+                        <Timestamp gameCreateTime={gameCreateTime} time={quotedMessage.time} />
                         <div className="quote-info">
                             {`${quotedMessage.senderName} in ${quotedMessage.meetingName}: `}
                         </div>
@@ -1275,10 +1281,12 @@ function Message(props) {
 }
 
 export function Timestamp(props) {
-    const time = new Date(props.time);
-    var hours = String(time.getHours()).padStart(2, "0");
-    var minutes = String(time.getMinutes()).padStart(2, "0");
-    var seconds = String(time.getSeconds()).padStart(2, "0");
+    const timestamp = Math.abs(new Date(props.time) - new Date(props.gameCreateTime));
+
+    // Convert millisecond difference into hours/minutes/seconds
+    let hours = String(Math.floor((timestamp / (1000 * 60 * 60)) % 24)).padStart(2, "0"),
+        minutes = String(Math.floor((timestamp / (1000 * 60)) % 60)).padStart(2, "0"),
+        seconds = String(Math.floor((timestamp / 1000) % 60)).padStart(2, "0");
 
     return (
         <div className="time">

--- a/react_main/src/pages/Game/Game.jsx
+++ b/react_main/src/pages/Game/Game.jsx
@@ -842,7 +842,7 @@ export function TopBar(props) {
 
 export function ThreePanelLayout(props) {
     return (
-        <div className="main">
+        <div className={"main " + (props.settings.fullscreen ? 'fullscreen' : '')}>
             <div className="left-panel panel">
                 {props.leftPanelContent}
             </div>
@@ -2116,6 +2116,12 @@ function SettingsModal(props) {
             value: settings.sounds
         },
         {
+            label: "Fullscreen",
+            ref: "fullscreen",
+            type: "boolean",
+            value: settings.fullscreen
+        },
+        {
             label: "Volume",
             ref: "volume",
             type: "range",
@@ -2797,6 +2803,7 @@ export function useSettingsReducer() {
         votingLog: true,
         timestamps: true,
         sounds: true,
+        fullscreen: true,
         volume: 1,
     };
 

--- a/react_main/src/pages/Game/MafiaGame.jsx
+++ b/react_main/src/pages/Game/MafiaGame.jsx
@@ -96,6 +96,7 @@ export default function MafiaGame() {
 						history={history} />
 				} />
 			<ThreePanelLayout
+        settings={game.settings}
 				leftPanelContent={
 					<>
 						<PlayerList

--- a/react_main/src/pages/Game/OneNightGame.jsx
+++ b/react_main/src/pages/Game/OneNightGame.jsx
@@ -95,6 +95,7 @@ export default function OneNightGame(props) {
 						history={history} />
 				} />
 			<ThreePanelLayout
+        settings={game.settings}
 				leftPanelContent={
 					<>
 						<PlayerList

--- a/react_main/src/pages/Game/ResistanceGame.jsx
+++ b/react_main/src/pages/Game/ResistanceGame.jsx
@@ -93,6 +93,7 @@ export default function ResistanceGame(props) {
 						history={history} />
 				} />
 			<ThreePanelLayout
+        settings={game.settings}
 				leftPanelContent={
 					<>
 						<PlayerList

--- a/react_main/src/pages/Game/SplitDecisionGame.jsx
+++ b/react_main/src/pages/Game/SplitDecisionGame.jsx
@@ -91,6 +91,7 @@ export default function SplitDecisionGame(props) {
 						history={history} />
 				} />
 			<ThreePanelLayout
+        settings={game.settings}
 				leftPanelContent={
 					<>
 						<PlayerList

--- a/routes/game.js
+++ b/routes/game.js
@@ -151,12 +151,13 @@ router.get("/:id/connect", async function (req, res) {
             return;
         }
 
+        let createTime = game.createTime;
         var type = game.type;
         var port = game.port;
         var token = userId && await redis.createAuthToken(userId);
 
         if (type && !isNaN(port))
-            res.send({ port, type, token });
+            res.send({ createTime, port, type, token });
         else {
             res.status(500);
             res.send("Error loading game.");


### PR DESCRIPTION
Resolves #861 and #860 

This adds the game's created time to the MongoDB model. It was already previously included in Redis.
The timestamp now takes the difference between current time and game's created time to get a relative timestamp for game time. On the backend, this should remain as real time for logging purposes.

Fullscreen setting was added. It is enabled by default.
The non-fullscreen CSS:
- Sets the sidebar panels to the higher width between 250px, or 15% of page width.
- Sets the center panel to the higher width between 600px, or 40% of page width.